### PR TITLE
Added height to coinbase as per BIP34

### DIFF
--- a/ntgbtminer.py
+++ b/ntgbtminer.py
@@ -126,7 +126,7 @@ def bitcoinaddress2hash160(s):
 #
 # Return the height encoded as per BIP 34
 # See: https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
-def encode_coinbase_nheight(n, min_size = 1):
+def encode_coinbase_height(n, min_size = 1):
   	s = bytearray(b'\1')
 
   	while n > 127:
@@ -154,10 +154,10 @@ def encode_coinbase_nheight(n, min_size = 1):
 #       value:              (unsigned int) value
 #
 # Returns transaction data in ASCII Hex
-def tx_make_coinbase(coinbase_script, address, value):
+def tx_make_coinbase(coinbase_script, address, value, height):
     # See https://en.bitcoin.it/wiki/Transaction
     
-    coinbase_script = bin2hex(encode_coinbase_nheight(312889)) + coinbase_script
+    coinbase_script = bin2hex(encode_coinbase_height(height)) + coinbase_script
 
     # Create a pubkey script
     # OP_DUP OP_HASH160 <len to push> <pubkey> OP_EQUALVERIFY OP_CHECKSIG
@@ -366,7 +366,7 @@ def block_mine(block_template, coinbase_message, extranonce_start, address, time
 
         # Update the coinbase transaction with the extra nonce
         coinbase_script = coinbase_message + int2lehex(extranonce, 4)
-        coinbase_tx['data'] = tx_make_coinbase(coinbase_script, address, block_template['coinbasevalue'])
+        coinbase_tx['data'] = tx_make_coinbase(coinbase_script, address, block_template['coinbasevalue'], block_template['height'])
         coinbase_tx['hash'] = tx_compute_hash(coinbase_tx['data'])
 
         # Recompute the merkle root

--- a/ntgbtminer.py
+++ b/ntgbtminer.py
@@ -116,6 +116,33 @@ def bitcoinaddress2hash160(s):
     return x[2:50-8]
 
 ################################################################################
+# Transaction coinbase height encoding
+################################################################################
+
+# Create a coinbase transaction
+#
+# Arguments:
+#       height:    the height of the mined block
+#
+# Return the height encoded as per BIP 34
+# See: https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
+def encode_coinbase_nheight(n, min_size = 1):
+  	s = bytearray(b'\1')
+
+  	while n > 127:
+  		s[0] += 1
+  		s.append(n % 256)
+  		n //= 256
+
+  	s.append(n)
+
+  	while len(s) < min_size + 1:
+  		s.append(0)
+  		s[0] += 1
+
+  	return bytes(s)
+
+################################################################################
 # Transaction Coinbase and Hashing Functions
 ################################################################################
 
@@ -129,6 +156,8 @@ def bitcoinaddress2hash160(s):
 # Returns transaction data in ASCII Hex
 def tx_make_coinbase(coinbase_script, address, value):
     # See https://en.bitcoin.it/wiki/Transaction
+    
+    coinbase_script = bin2hex(encode_coinbase_nheight(312889)) + coinbase_script
 
     # Create a pubkey script
     # OP_DUP OP_HASH160 <len to push> <pubkey> OP_EQUALVERIFY OP_CHECKSIG
@@ -400,4 +429,3 @@ def standalone_miner(coinbase_message, address):
 
 if __name__ == "__main__":
     standalone_miner(bin2hex("Hello from vsergeev!"), "15PKyTs3jJ3Nyf3i6R7D9tfGCY1ZbtqWdv")
-


### PR DESCRIPTION
As per BIP34, the first item in the coinbase transaction's scriptSig must be the height of the block mined, otherwise the block will be rejected.